### PR TITLE
Close file stream for config.cfg

### DIFF
--- a/foundry/FoundryInstance.cs
+++ b/foundry/FoundryInstance.cs
@@ -276,7 +276,7 @@ namespace Foundry
 		{
 			OpenedConfig = new Config();
 
-			if (!File.Exists(ConfigFile)) File.Create(ConfigFile);
+			if (!File.Exists(ConfigFile)) File.Create(ConfigFile).Close();
 
 			string[] cfg = File.ReadAllLines(ConfigFile);
 


### PR DESCRIPTION
Only applies on the first launch of Foundry, user would need to restart the application for it to work if we don't close the file stream.